### PR TITLE
fix: use json encode instead of str

### DIFF
--- a/utils.star
+++ b/utils.star
@@ -7,7 +7,7 @@ def get_agent_config_artifact(plan, agent_config_json):
     else:
         return plan.render_templates(config={
                 "agent_config.json": struct(
-                    template=str(agent_config_json),
+                    template=json.encode(agent_config_json),
                     data={},
                 ),
             },


### PR DESCRIPTION
`str()` function turned valid json:
```
{
  "isTestnet": true,
}
```
into invalid json:
```
{
  "isTestnet": True
}
```
This caused a bug where `agent_config_json` was unable to be parsed. 

This PR fixes this bug by using `json.encode`, a starlark function that correctly turns a json object into an accurate json string. Fixes https://github.com/kurtosis-tech/kurtosis/issues/1500