### PR TITLE
Add more validation

### DIFF
--- a/main.star
+++ b/main.star
@@ -53,9 +53,13 @@ def run(
     if len(aws_bucket_folder) > 0:
         aws_env["aws_bucket_user_folder"] = aws_bucket_folder
 
-    relay_chains = relay_chains.split(",")
+    relay_chains = [chain.strip() for chain in relay_chains.split(',')]
     if len(relay_chains) < 2:
         fail("At least two chains must be provided to relay between")
+
+    if len(validator_key) < 64:
+        fail("Invalid validator key provided")
+    validator_key = validator_key if validator_key.startswith("0x") else "0x" + validator_key
 
     env_aws = get_aws_user_info(plan, aws_env)
 


### PR DESCRIPTION
Fixes the following problems

Issues that were reported by people trying to set up agents via Kurtosis:
- filling in a private key that is not 0x prefixed
- filling in the relayChains list with spaces after the commas (e.g. `sepolia, goerli`, instead of `sepolia,goerli`)

The agents will crash in the cases above

Fixes https://github.com/hyperlane-xyz/issues/issues/770